### PR TITLE
Changed the X150Status message attribute from compass_mag to yaw_deg

### DIFF
--- a/msg/X150Status.msg
+++ b/msg/X150Status.msg
@@ -14,6 +14,6 @@ float32 sound_mps
 #
 # Attitude
 #
-float32 compass_mag
+float32 yaw_deg
 float32 pitch_deg
 float32 roll_deg


### PR DESCRIPTION
The Attitude values in the X150 StatusResp message does NOT contain a magnetic compass heading. It's instead a yaw value relative to magnetic North. There's still uncertainty about whether it requires an offset.

Testing manually by starting the delivery_node.py and using rqt to watch the yaw_deg values change as the X150 is rotated by hand inside the building. The published values are reasonable yaw values, but are not consistently negative and positive relative to the orientation of the X150.