### PR TITLE
Renamed the RangeBearing message attribute mag_heading_deg

### DIFF
--- a/msg/RangeBearing.msg
+++ b/msg/RangeBearing.msg
@@ -7,10 +7,11 @@ std_msgs/Header header
 #
 
 #
-# Orientation of the X150.
+# Orientation of the X150. yaw_deg is an offset from magnetic
+# North.
 #
 bool orientation_present
-float32 mag_heading_deg
+float32 yaw_deg
 float32 roll_deg
 float32 pitch_deg
 
@@ -27,16 +28,17 @@ bool range_present
 float32 range_m
 
 #
-# The azimuth and elevation from the X150 to the X110 in degrees,
-# relative to the X150 and its orientation.
+# The azimuth and elevation of the X110 in degrees,
+# relative to the X150 and its orientation. azimuth_deg is
+# [0, 360] and relative to the "front" of the X150. elevation_deg
+# is [-90, 90] and relative to the X-Y plane.
 #
 float32 azimuth_deg
 float32 elevation_deg
 
 #
-# The position of the remote X110, relative to the X150. Depth
-# is provided by the X110.
-#
+# The position of the remote X110, relative to the X150.
+# The depth of the X110 is calculated by the X150.
 float32 remote_east_m
 float32 remote_north_m
 float32 remote_depth_m

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>usbl_msgs</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>Message definition for exchanging USBL information.</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ package_name = 'usbl_msgs'
 
 setup(
     name=package_name,
-    version='0.0.2',
+    version='0.0.3',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
Requires [PR6](https://github.com/billmania/delivery/pull/6) from the delivery repository.

This is a breaking change for historical bag files, due to a change in the definition of the RangeBearing message.

The RangeBearing message had an attribute named mag_heading_deg, which implied its value was a heading. That attribute was renamed to yaw_deg because it's not a heading. Instead, it's an offset from magnetic North, as determined by the X150. See the description for ATTITUDE_YAW on page 50 of [blueprint SeaTrac Developer Guide](https://www.blueprintsubsea.com/downloads/seatrac/UM-140-D00221-07.pdf) for the details.

